### PR TITLE
[update]複数の画像拡張子対応

### DIFF
--- a/.github/workflows/Schedule.yml
+++ b/.github/workflows/Schedule.yml
@@ -28,7 +28,7 @@ concurrency:  # 同時にworkflowが実行されたらキャンセル
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 5    # 5分過ぎたら強制終了
+    timeout-minutes: 10    # 10分過ぎたら強制終了
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/Schedule.yml
+++ b/.github/workflows/Schedule.yml
@@ -35,20 +35,23 @@ jobs:
         with:
           python-version: '3.x'
           architecture: 'x64'
-      - name: run python
-        id: results
+      - uses: actions/cache@v3
+        id: cache
+        with:
+          path: /opt/hostedtoolcache/Python
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+      - name: pip install
+        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
           echo "::group::pip install --upgrade pip"
           python -m pip install --upgrade pip==23.0
-          pip install get-chrome-driver==1.3.10
-          pip install selenium==4.8.0
-          pip install opencv-python==4.7.0.68
-          pip install python-opencv-utils==0.0.4
-          pip install tweepy==4.12.1
-          pip install gspread==5.7.2
-          pip install oauth2client==4.1.3
+          pip install -r requirements.txt
           echo "::endgroup::"
-          python -B schedule.py
+      - name: run python
+        id: results
+        run: python -B schedule.py
       - name: GitHub_Summary
         run: |
           echo -e "- #### 時刻: ${{steps.results.outputs.TIME}}" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/Schedule.yml
+++ b/.github/workflows/Schedule.yml
@@ -35,23 +35,20 @@ jobs:
         with:
           python-version: '3.x'
           architecture: 'x64'
-      - uses: actions/cache@v3
-        id: cache
-        with:
-          path: /opt/hostedtoolcache/Python
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-      - name: pip install
-        if: ${{ steps.cache.outputs.cache-hit != 'true' }}
+      - name: run python
+        id: results
         run: |
           echo "::group::pip install --upgrade pip"
           python -m pip install --upgrade pip==23.0
-          pip install -r requirements.txt
+          pip install get-chrome-driver==1.3.10
+          pip install selenium==4.8.0
+          pip install opencv-python==4.7.0.68
+          pip install python-opencv-utils==0.0.4
+          pip install tweepy==4.12.1
+          pip install gspread==5.7.2
+          pip install oauth2client==4.1.3
           echo "::endgroup::"
-      - name: run python
-        id: results
-        run: python -B schedule.py
+          python -B schedule.py
       - name: GitHub_Summary
         run: |
           echo -e "- #### 時刻: ${{steps.results.outputs.TIME}}" >> $GITHUB_STEP_SUMMARY

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,0 @@
-pip install get-chrome-driver==1.3.10
-pip install selenium==4.8.0
-pip install opencv-python==4.7.0.68
-pip install python-opencv-utils==0.0.4
-pip install tweepy==4.12.1
-pip install gspread==5.7.2
-pip install oauth2client==4.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+get-chrome-driver==1.3.10
+selenium==4.8.0
+opencv-python==4.7.0.68
+python-opencv-utils==0.0.4
+tweepy==4.12.1
+gspread==5.7.2
+oauth2client==4.1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-get-chrome-driver==1.3.10
-selenium==4.8.0
-opencv-python==4.7.0.68
-python-opencv-utils==0.0.4
-tweepy==4.12.1
-gspread==5.7.2
-oauth2client==4.1.3
+pip install get-chrome-driver==1.3.10
+pip install selenium==4.8.0
+pip install opencv-python==4.7.0.68
+pip install python-opencv-utils==0.0.4
+pip install tweepy==4.12.1
+pip install gspread==5.7.2
+pip install oauth2client==4.1.3

--- a/schedule.py
+++ b/schedule.py
@@ -129,6 +129,10 @@ for index, e in enumerate(imgs_tag, 1):
         else:
             img_url = upload_imgur(img_url)
         print(' → ' + img_url)
+        if 'png' in img_url:
+            cell = 'C6'
+        else:
+            cell = 'C7'
         if bool(str(cv2u.urlread(img_url)) in imgs_cv2u_now) == False:
             print(' → append')
             imgs_cv2u_now.append(str(cv2u.urlread(img_url)))
@@ -150,7 +154,7 @@ gc = gspread.authorize(ServiceAccountCredentials.from_json_keyfile_name('gss.jso
 ws = gc.open_by_key(os.environ['SHEET_ID']).sheet1
 
 # 最後に投稿した画像のリストを読み込み
-imgs_url_latest = ws.acell('C6').value.split()    # URLリスト(過去)
+imgs_url_latest = ws.acell(cell).value.split()    # URLリスト(過去)
 print(imgs_url_latest)
 imgs_cv2u_latest = []    # cv2u用リスト(過去)
 for e in imgs_url_latest:
@@ -182,8 +186,7 @@ for i in imgs_url_now:
             local_file.write(data)
 
 # 上書き
-ws.update_acell('C6', ' \n'.join(imgs_url_now))
-ws.update_acell('C2', time_now)
+ws.update_acell(cell, ' \n'.join(imgs_url_now))
 ws.update_acell('C3', 'https://github.com/Geusen/Schedule_Bot/actions/runs/' + str(os.environ['RUN_ID']))
 
 #----------------------------------------------------------------------------------------------------`

--- a/schedule.py
+++ b/schedule.py
@@ -190,38 +190,38 @@ ws.update_acell(cell, ' \n'.join(imgs_url_now))
 ws.update_acell('C3', 'https://github.com/Geusen/Schedule_Bot/actions/runs/' + str(os.environ['RUN_ID']))
 
 #----------------------------------------------------------------------------------------------------`
-# tweepyの設定(認証情報を設定、APIインスタンスの作成)
-auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
-auth.set_access_token(access_token, access_token_secret)
-api = tweepy.API(auth, wait_on_rate_limit=True)
+# # tweepyの設定(認証情報を設定、APIインスタンスの作成)
+# auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
+# auth.set_access_token(access_token, access_token_secret)
+# api = tweepy.API(auth, wait_on_rate_limit=True)
 
-# ツイート
-media_ids = []
-for image in imgs_path:
-   img = api.media_upload(image)
-   media_ids.append(img.media_id)
-api.update_status(status='時間割が更新されました！', media_ids=media_ids)
+# # ツイート
+# media_ids = []
+# for image in imgs_path:
+#    img = api.media_upload(image)
+#    media_ids.append(img.media_id)
+# api.update_status(status='時間割が更新されました！', media_ids=media_ids)
 
-# LINEへ通知
-line_dict = {'公式グループ' : notify_group, '27組' : notify_27, '13組' : notify_13}
-print('\n[LINE]')
-for key, value in line_dict.items():
-    for i, image in enumerate(imgs_path, 1):
-        print(key + '-' + str(i) + '枚目: ' + line_notify(value, image))
+# # LINEへ通知
+# line_dict = {'公式グループ' : notify_group, '27組' : notify_27, '13組' : notify_13}
+# print('\n[LINE]')
+# for key, value in line_dict.items():
+#     for i, image in enumerate(imgs_path, 1):
+#         print(key + '-' + str(i) + '枚目: ' + line_notify(value, image))
 
-# DiscordのWebhookを通して通知
-payload2 = {'payload_json' : {'content' : '@everyone\n時間割が更新されました。'}}
-embed = []
-# 画像の枚数分"embed"の値追加
-for i in imgs_url_now:
-    if imgs_url_now.index(i) == 0:
-        img_embed = {'color' : 10931421, 'url' : 'https://www.google.com/', 'image' : {'url' : i}}
-    else:
-        img_embed = {'url' : 'https://www.google.com/', 'image' : {'url' : i}}
-    embed.append(img_embed)
-payload2['payload_json']['embeds'] = embed
-payload2['payload_json'] = json.dumps(payload2['payload_json'], ensure_ascii=False)
-res = requests.post(webhook_url, data=payload2)
-print('Discord_Webhook: ' + str(res.status_code))
-res.raise_for_status()
-finish('投稿完了')
+# # DiscordのWebhookを通して通知
+# payload2 = {'payload_json' : {'content' : '@everyone\n時間割が更新されました。'}}
+# embed = []
+# # 画像の枚数分"embed"の値追加
+# for i in imgs_url_now:
+#     if imgs_url_now.index(i) == 0:
+#         img_embed = {'color' : 10931421, 'url' : 'https://www.google.com/', 'image' : {'url' : i}}
+#     else:
+#         img_embed = {'url' : 'https://www.google.com/', 'image' : {'url' : i}}
+#     embed.append(img_embed)
+# payload2['payload_json']['embeds'] = embed
+# payload2['payload_json'] = json.dumps(payload2['payload_json'], ensure_ascii=False)
+# res = requests.post(webhook_url, data=payload2)
+# print('Discord_Webhook: ' + str(res.status_code))
+# res.raise_for_status()
+# finish('投稿完了')

--- a/schedule.py
+++ b/schedule.py
@@ -1,24 +1,25 @@
+# 標準ライブラリ
 import ast
 import base64  # blob対策
 import datetime  # 日付取得
+import io
 import json  # webhook用
 import os  # 環境変数用
 import subprocess  # GitHubActionsの環境変数追加
 import time  # 待機
 import urllib.request  # 画像取得
+# サードパーティ製ライブラリ
 import cv2
 import gspread
 import numpy as np
 import requests  # LINE・Discord送信
 import tweepy  # Twitter送信
 from oauth2client.service_account import ServiceAccountCredentials
+from PIL import Image
 from selenium import webdriver  # サイトから画像取得(以下略)
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
-from PIL import Image
-import io
-
 
 #----------------------------------------------------------------------------------------------------
 # バグが発生した場合様々が情報が必要になるため、日付を取得(日本時間)
@@ -190,38 +191,38 @@ ws.update_acell('C6', ' \n'.join(imgs_url_now))
 ws.update_acell('C3', 'https://github.com/Geusen/Schedule_Bot/actions/runs/' + str(os.environ['RUN_ID']))
 
 #----------------------------------------------------------------------------------------------------`
-# # tweepyの設定(認証情報を設定、APIインスタンスの作成)
-# auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
-# auth.set_access_token(access_token, access_token_secret)
-# api = tweepy.API(auth, wait_on_rate_limit=True)
+# tweepyの設定(認証情報を設定、APIインスタンスの作成)
+auth = tweepy.OAuthHandler(consumer_key, consumer_secret)
+auth.set_access_token(access_token, access_token_secret)
+api = tweepy.API(auth, wait_on_rate_limit=True)
 
-# # ツイート
-# media_ids = []
-# for image in imgs_path:
-#    img = api.media_upload(image)
-#    media_ids.append(img.media_id)
-# api.update_status(status='時間割が更新されました！', media_ids=media_ids)
+# ツイート
+media_ids = []
+for image in imgs_path:
+   img = api.media_upload(image)
+   media_ids.append(img.media_id)
+api.update_status(status='時間割が更新されました！', media_ids=media_ids)
 
-# # LINEへ通知
-# line_dict = {'公式グループ' : notify_group, '27組' : notify_27, '13組' : notify_13}
-# print('\n[LINE]')
-# for key, value in line_dict.items():
-#     for i, image in enumerate(imgs_path, 1):
-#         print(key + '-' + str(i) + '枚目: ' + line_notify(value, image))
+# LINEへ通知
+line_dict = {'公式グループ' : notify_group, '27組' : notify_27, '13組' : notify_13}
+print('\n[LINE]')
+for key, value in line_dict.items():
+    for i, image in enumerate(imgs_path, 1):
+        print(key + '-' + str(i) + '枚目: ' + line_notify(value, image))
 
-# # DiscordのWebhookを通して通知
-# payload2 = {'payload_json' : {'content' : '@everyone\n時間割が更新されました。'}}
-# embed = []
-# # 画像の枚数分"embed"の値追加
-# for i in imgs_url_now:
-#     if imgs_url_now.index(i) == 0:
-#         img_embed = {'color' : 10931421, 'url' : 'https://www.google.com/', 'image' : {'url' : i}}
-#     else:
-#         img_embed = {'url' : 'https://www.google.com/', 'image' : {'url' : i}}
-#     embed.append(img_embed)
-# payload2['payload_json']['embeds'] = embed
-# payload2['payload_json'] = json.dumps(payload2['payload_json'], ensure_ascii=False)
-# res = requests.post(webhook_url, data=payload2)
-# print('Discord_Webhook: ' + str(res.status_code))
-# res.raise_for_status()
-# finish('投稿完了')
+# DiscordのWebhookを通して通知
+payload2 = {'payload_json' : {'content' : '@everyone\n時間割が更新されました。'}}
+embed = []
+# 画像の枚数分"embed"の値追加
+for i in imgs_url_now:
+    if imgs_url_now.index(i) == 0:
+        img_embed = {'color' : 10931421, 'url' : 'https://www.google.com/', 'image' : {'url' : i}}
+    else:
+        img_embed = {'url' : 'https://www.google.com/', 'image' : {'url' : i}}
+    embed.append(img_embed)
+payload2['payload_json']['embeds'] = embed
+payload2['payload_json'] = json.dumps(payload2['payload_json'], ensure_ascii=False)
+res = requests.post(webhook_url, data=payload2)
+print('Discord_Webhook: ' + str(res.status_code))
+res.raise_for_status()
+finish('投稿完了')

--- a/schedule.py
+++ b/schedule.py
@@ -173,6 +173,7 @@ subprocess.run([f'echo BEFORE={before} >> $GITHUB_OUTPUT'], shell=True)
 # 比較
 if len(imgs_url_now) == len(imgs_url_latest):
     if ext == 'jpeg':
+        print('jpeg')
         imgs_cv2u_now = []
         imgs_cv2u_latest = []
         for i in imgs_url_now:
@@ -181,6 +182,7 @@ if len(imgs_url_now) == len(imgs_url_latest):
         for i in imgs_url_latest:
             Image.open(io.BytesIO(requests.get(i).content)).save('latest.eps', lossless = True)
             imgs_cv2u_latest.append(cv2.imread('latest.eps'))
+            print('jpeg → eps')
     if bool(set(imgs_cv2u_now) == set(imgs_cv2u_latest)) == True:
         finish('画像が一致した為、終了')
     else:


### PR DESCRIPTION
## 1.変更点
<!-- このプルリクエストの変更点を箇条書きで、この行の下から書いてください。 -->
- 「cv2uを用いて画像のURLから画像の情報を読み取る」方式から、「pillowとcv2を用いて画像のURLから.epsファイル作成、画像の情報を読取る」方式へ変更
  - これにより画像の拡張子が.pngでも.jpegでも対応、誤爆がなくなる


## 2.レビューで見てほしいポイント(要レビュー時記載)
<!-- この行の下から書いてください。 -->
- 特になし


## 3.関連Issue
<!-- #1 と書くと Issue 1 へリンクされます。 -->
- #21


## 4.補足(任意)
- .png、.jpeg以外は未検証


## 5.参考リンク(任意)
<!-- [タイトル](URL) 書式でリンクになります。 -->
- [png,jpeg,gif画像をeps形式に変換する](https://qiita.com/h-nabata/items/100057e9823f9878eeb9)
- [pillowモジュールにおいてURLから直接画像を読み込む](https://qiita.com/tamanobi/items/e135839bb8115792c185)